### PR TITLE
Update `QuestionHandler` class to hide an exposed API key

### DIFF
--- a/scripts/GptPrompter.py
+++ b/scripts/GptPrompter.py
@@ -251,7 +251,7 @@ class QuestionHandler:
         self.utterance = utterance
         self.source_csv = os.path.join(base_path, source_csv)
         self.target_value = target_value
-        self.API_key = "sk-oMs1jGJzVhRAuypxQRJhZwq6xh6obRMLLPsMY8ZA"
+        self.API_key = openai.api_key
         self._read_data()
         self.execution_acc = None
         self.execution_err = None


### PR DESCRIPTION
I have seen that in `QuestionHandler`, you simply show your API key in it. 

Here is what i see
```python
self.API_key = "sk-[YOUR LEAKED KEY HERE]-ZA"
```

Even though the key is expired, it is much safer to keep an api key always be private by the owner. Here i've made a quick PR to hide them. if there has any problem with my PR, please suggest me 👍🏻 